### PR TITLE
Update Node to 22, gscan to 5.x, and ubuntu to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
         node: [ '22' ]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,21 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
-      fail-fast: false
       matrix:
-        include:
-          - node: '10'
-            gscan: '4.1.4'
-          - node: '22'
-            gscan: '5.2.4'
+        node: [ '22' ]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - name: Pin gscan version
-        run: |
-          sed -i 's/"gscan": ".*"/"gscan": "${{ matrix.gscan }}"/' package.json
       - run: yarn
       - run: yarn test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
         node: [ '22' ]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       - run: yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ '10' ]
+        node: [ '10', '24' ]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Pin gscan version
-        run: sed -i 's/"gscan": ".*"/"gscan": "${{ matrix.gscan }}"/' package.json
+        run: |
+          sed -i 's/"gscan": ".*"/"gscan": "${{ matrix.gscan }}"/' package.json
       - run: yarn
       - run: yarn test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ '10', '24' ]
+        node: [ '10', '22' ]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,23 @@ on:
       - 'renovate/*'
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
+      fail-fast: false
       matrix:
-        node: [ '10', '22' ]
+        include:
+          - node: '10'
+            gscan: '4.1.4'
+          - node: '22'
+            gscan: '5.2.4'
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+      - name: Pin gscan version
+        run: sed -i 's/"gscan": ".*"/"gscan": "${{ matrix.gscan }}"/' package.json
       - run: yarn
       - run: yarn test:ci

--- a/package.json
+++ b/package.json
@@ -1,90 +1,90 @@
 {
-    "name": "tribeca",
-    "description": "A custom theme for ghost",
-    "demo": "https://tribeca.ghost.io",
-    "version": "1.0.0",
-    "engines": {
-        "ghost": ">=4.0.0",
-        "ghost-api": "v4"
-    },
-    "license": "MIT",
-    "screenshots": {
-        "desktop": "assets/screenshot-desktop.jpg"
-    },
-    "scripts": {
-        "dev": "gulp",
-        "zip": "gulp zip",
-        "test": "gscan .",
-        "test:ci": "gscan --fatal --verbose .",
-        "pretest": "gulp build",
-        "preship": "yarn test",
-        "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version && git push --follow-tags; fi"
-    },
-    "author": {
-        "name": "Ghost Foundation",
-        "email": "hello@ghost.org",
-        "url": "https://ghost.org"
-    },
-    "gpm": {
-        "type": "theme",
-        "categories": [
-            "Minimal",
-            "Magazine"
-        ]
-    },
-    "keywords": [
-        "ghost",
-        "theme",
-        "ghost-theme"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/TryGhost/Tribeca.git"
-    },
-    "bugs": "https://github.com/TryGhost/Tribeca/issues",
-    "contributors": "https://github.com/TryGhost/Tribeca/graphs/contributors",
-    "devDependencies": {
-        "autoprefixer": "10.4.14",
-        "beeper": "2.1.0",
-        "cssnano": "5.1.15",
-        "gscan": "4.1.4",
-        "gulp": "4.0.2",
-        "gulp-livereload": "4.0.2",
-        "gulp-postcss": "9.0.1",
-        "gulp-sourcemaps": "3.0.0",
-        "gulp-uglify": "3.0.2",
-        "gulp-util": "3.0.8",
-        "gulp-watch": "5.0.1",
-        "gulp-zip": "5.1.0",
-        "postcss": "8.4.21",
-        "postcss-color-function": "4.1.0",
-        "postcss-custom-properties": "11.0.0",
-        "postcss-easy-import": "3.0.0"
-    },
-    "browserslist": [
-        "defaults"
-    ],
-    "config": {
-        "posts_per_page": 15,
-        "image_sizes": {
-            "xxs": {
-                "width": 30
-            },
-            "xs": {
-                "width": 100
-            },
-            "s": {
-                "width": 300
-            },
-            "m": {
-                "width": 600
-            },
-            "l": {
-                "width": 1200
-            },
-            "xl": {
-                "width": 2000
-            }
-        }
+  "name": "tribeca",
+  "description": "A custom theme for ghost",
+  "demo": "https://tribeca.ghost.io",
+  "version": "1.0.0",
+  "engines": {
+    "ghost": ">=4.0.0",
+    "ghost-api": "v4"
+  },
+  "license": "MIT",
+  "screenshots": {
+    "desktop": "assets/screenshot-desktop.jpg"
+  },
+  "scripts": {
+    "dev": "gulp",
+    "zip": "gulp zip",
+    "test": "gscan .",
+    "test:ci": "gscan --fatal --verbose .",
+    "pretest": "gulp build",
+    "preship": "yarn test",
+    "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version && git push --follow-tags; fi"
+  },
+  "author": {
+    "name": "Ghost Foundation",
+    "email": "hello@ghost.org",
+    "url": "https://ghost.org"
+  },
+  "gpm": {
+    "type": "theme",
+    "categories": [
+      "Minimal",
+      "Magazine"
+    ]
+  },
+  "keywords": [
+    "ghost",
+    "theme",
+    "ghost-theme"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TryGhost/Tribeca.git"
+  },
+  "bugs": "https://github.com/TryGhost/Tribeca/issues",
+  "contributors": "https://github.com/TryGhost/Tribeca/graphs/contributors",
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "beeper": "2.1.0",
+    "cssnano": "5.1.15",
+    "gscan": "5.2.4",
+    "gulp": "4.0.2",
+    "gulp-livereload": "4.0.2",
+    "gulp-postcss": "9.0.1",
+    "gulp-sourcemaps": "3.0.0",
+    "gulp-uglify": "3.0.2",
+    "gulp-util": "3.0.8",
+    "gulp-watch": "5.0.1",
+    "gulp-zip": "5.1.0",
+    "postcss": "8.4.21",
+    "postcss-color-function": "4.1.0",
+    "postcss-custom-properties": "11.0.0",
+    "postcss-easy-import": "3.0.0"
+  },
+  "browserslist": [
+    "defaults"
+  ],
+  "config": {
+    "posts_per_page": 15,
+    "image_sizes": {
+      "xxs": {
+        "width": 30
+      },
+      "xs": {
+        "width": 100
+      },
+      "s": {
+        "width": 300
+      },
+      "m": {
+        "width": 600
+      },
+      "l": {
+        "width": 1200
+      },
+      "xl": {
+        "width": 2000
+      }
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "autoprefixer": "10.4.14",
     "beeper": "2.1.0",
     "cssnano": "5.1.15",
-    "gscan": "4.1.4",
+    "gscan": "5.2.4",
     "gulp": "4.0.2",
     "gulp-livereload": "4.0.2",
     "gulp-postcss": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "autoprefixer": "10.4.14",
     "beeper": "2.1.0",
     "cssnano": "5.1.15",
-    "gscan": "5.2.4",
+    "gscan": "4.1.4",
     "gulp": "4.0.2",
     "gulp-livereload": "4.0.2",
     "gulp-postcss": "9.0.1",


### PR DESCRIPTION
- Update test matrix from Node 10 → Node 22
- Update gscan 4.1.4 → 5.2.4
- Update ubuntu-18.04 → ubuntu-latest
- Update actions/checkout v3 → v6
- Update actions/setup-node v3 → v6