### PR TITLE
Update Renovate config to use @tryghost default preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,4 @@
 {
-  "extends": [
-    "@tryghost:theme"
-  ],
-  "node": {
-    "supportPolicy": ["lts_latest"]
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["@tryghost"]
 }


### PR DESCRIPTION
- Replace broken `@tryghost:theme` preset (never existed) with `@tryghost` default
- Remove deprecated `node.supportPolicy` option
- Fixes Renovate configuration error (issue #20 on Tribeca)