### PR TITLE
Add build step to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,5 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: yarn
+      - run: gulp build
       - run: yarn test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,5 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: yarn
       - run: gulp build
+      - run: gulp zip
       - run: yarn test:ci


### PR DESCRIPTION
- Run `gulp build` before `gscan` in CI
- Ensures the theme compiles correctly, not just passes linting
- The repo's `pretest` script already does this for `yarn test`, but `test:ci` bypasses it