### PR TITLE
Fixed broken pnpm/action-setup pin and excluded workspace file from zip

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,6 +76,7 @@ async function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!pnpm-lock.yaml',
+            '!pnpm-workspace.yaml',
             '!pnpm-debug.log'
         ]),
         zipModule(filename),


### PR DESCRIPTION
## Summary

- Replaced the `pnpm/action-setup` digest `ac6db6d3c1f721f886538a378a2d73e85697340a` with `0e279bb959325dab635dd2c09392533439d90093` in both workflow files. The old digest no longer exists upstream (GitHub returns HTTP 422 for it), so any workflow job using it fails to resolve the action. The new digest is the verified SHA behind the current `v6`/`v6.0.8` tag. Discovered during the TryGhost/Themes#529 pnpm migration review.
- Added `'!pnpm-workspace.yaml'` to the gulp zip task's exclusions. The file is development tooling (pnpm 11 build-script approvals) and does not belong in the installable theme zip.

## Verification

- `pnpm install --frozen-lockfile` succeeds.
- `pnpm zip` builds `dist/tribeca.zip`; `unzip -l dist/tribeca.zip | grep -i pnpm` returns no matches (no pnpm files in the zip, 50 files total).
- Diff is scoped to the two workflow files and `gulpfile.js` only.