### PR TITLE
Exclude agent docs from theme zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,6 +77,8 @@ async function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-lock.yaml',
             '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
             '!pnpm-debug.log'
         ]),
         zipModule(filename),


### PR DESCRIPTION
## Summary
- Excludes `AGENTS.md` and `CLAUDE.md` from the theme zip source globs.
- Keeps generated theme archives limited to runtime theme content.

## Validation
- `pnpm zip`, with the generated archive inspected for `AGENTS.md` / `CLAUDE.md`.
