### PR TITLE
Renamed CI gate to the org-standard "Required checks pass" check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
 
       - run: pnpm test
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Branch protection on this repo currently requires a status check named exactly "All tests pass". Requiring individual or legacy check names couples branch protection to the CI matrix: rename a job (or the gate itself) and the required check silently stops existing, blocking every PR.

The org is standardizing every repository on one stable aggregator check named "Required checks pass" (the aggregator-gate convention). This PR renames the existing gate job accordingly:

- job id: `required-checks-pass`, `name: Required checks pass`
- `if: always()` with `needs: [test]` — coverage identical to the old gate (`test` is the only other job in the workflow)
- single verify step failing on any `failure`/`cancelled` result, unchanged

The branch ruleset is being updated in the same pass to require "Required checks pass", so this PR must go green on the new gate before merge.